### PR TITLE
Feat/dataset utils

### DIFF
--- a/.github/workflows/manual_rebuild_dataset.yml
+++ b/.github/workflows/manual_rebuild_dataset.yml
@@ -1,0 +1,36 @@
+# simple workflow that runs a python script to rebuild the dataset
+# it should be triggered only manually (workflow_dispatch)
+
+name: Manually Rebuild Dataset
+on:
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      environment:
+        description: 'Environment to deploy'
+        required: false
+        default: 'staging'
+jobs:
+    rebuild_dataset:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+            
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: '3.10'
+    
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+    
+        - name: Rebuild Dataset
+          env:
+            HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          run: python rebuild_dataset.py

--- a/rebuild_dataset.py
+++ b/rebuild_dataset.py
@@ -1,0 +1,28 @@
+'''
+This script builds a new dataset from scratch, from all the
+observations stored in the huggingface hub.
+
+It is intended to be used rarely, e.g. when the data format
+has changed, and we need to rebuild the dataset from scratch;
+and so we don't expect a cron/continuous action triggering it.
+'''
+
+import os 
+from huggingface_hub import HfApi
+from src.dataset_handling import reset_dataset_rebuild_from_json
+
+
+############################################################
+dataset_id = "Saving-Willy/temp_dataset"
+token = os.getenv("HF_TOKEN")
+dataset_filename = "data/train-00000-of-00001.parquet"
+############################################################
+
+if __name__ == '__main__':
+    # Initialize API client
+    api = HfApi(token=token)
+
+    # run the full rebuild/reset, and push to hub
+    reset_dataset_rebuild_from_json(
+        api, dataset_id)
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-huggingface_hub
-datasets
+huggingface_hub~=0.26.1
+datasets~=3.0.0
+pyarrow~=18.1.0
 
+# actually a bit over the top, it is just to pretty-print a table
+pandas~=2.2.3

--- a/src/dataset_handling.py
+++ b/src/dataset_handling.py
@@ -144,7 +144,7 @@ def sync_dataset(
         print(f"Dataset found in {dataset_filename}. Proceeding with sync.")
 
     # 2. add the content of any new ones into the dataset
-    n = add_json_files_to_metadata(json_files, dataset)
+    n = add_json_files_to_metadata(json_files, dataset, dataset_id)
     # 3. push the updated one into HF hub
     if n > 0:
         try:
@@ -188,7 +188,7 @@ def reset_dataset_rebuild_from_json(api:HfApi, dataset_id:str) -> DatasetDict:
     delete_metadata_if_exists(api, dataset_id, parquet_fname="data/train-00000-of-00001.parquet")
     metadata = create_blank_dataset()
     json_files = lookup_json_files(api, dataset_id)
-    n = add_json_files_to_metadata(json_files, metadata)
+    n = add_json_files_to_metadata(json_files, metadata, dataset_id)
     print(f"Added {n} files to metadata.")
     print(pd.DataFrame(metadata['train']))
 

--- a/src/dataset_handling.py
+++ b/src/dataset_handling.py
@@ -81,10 +81,20 @@ def add_json_files_to_metadata(add_files: List[str], metadata: DatasetDict, data
         with open(file, "r") as f:
             new = json.load(f)
         
-        if ("image_md5" not in metadata["train"]) or \
-            not (new["image_md5"] in metadata["train"]["image_md5"]):
+        
+        
+        if ("image_md5" not in metadata["train"].column_names):
+            # new dataset, no 'image_md5' dict to test for keys
             metadata["train"] = metadata["train"].add_item(new)
             n += 1
+        elif new["image_md5"] not in metadata["train"]["image_md5"]:
+            # dataset exists, but this image wasn't seen before
+            metadata["train"] = metadata["train"].add_item(new)
+            n += 1
+        else:
+            # this image was seen before, so we skip it
+            print(f"Skipping {new['image_md5']} as it already exists in the dataset.")
+            
     return n
 
         

--- a/src/dataset_handling.py
+++ b/src/dataset_handling.py
@@ -1,0 +1,147 @@
+from typing import List
+import json
+import pandas as pd
+
+import pyarrow
+from datasets import load_dataset
+from datasets import Dataset, DatasetDict
+from huggingface_hub import HfApi, hf_hub_download
+
+def create_blank_dataset(dataset_key:str="train"):
+    """
+    Creates a blank Hugging Face DatasetDict with an empty dataset for the specified field type.
+
+    Args:
+        dataset_key (str): The key for the dataset in the DatasetDict. Defaults to 'train'.
+
+    Returns:
+        DatasetDict: A dictionary containing a single key with the specified field type and an empty Dataset.
+    """
+    blank_dataset = DatasetDict()
+    blank_dataset[dataset_key] = Dataset(pyarrow.table([]))
+    return blank_dataset
+  
+
+def delete_metadata_if_exists(
+    api: HfApi, dataset_id: str, 
+    parquet_fname: str = "data/train-00000-of-00001.parquet"):
+    """
+    Deletes a specified file from a dataset repository if it exists.
+
+    Args:
+        api (HfApi): An instance of the Hugging Face API client.
+        dataset_id (str): The identifier of the dataset repository.
+        parquet_fname (str, optional): The name of the file to check and delete. 
+            Defaults to "data/train-00000-of-00001.parquet".
+
+    """
+    # does file exist? (could lookup by wildcard, eg train-*.parquet)?
+    if api.file_exists(repo_id=dataset_id, filename=parquet_fname, repo_type="dataset"):
+        print(f"File {parquet_fname} in dataset {dataset_id} exists.")
+        # then delete
+        try:
+            api.delete_file(repo_id=dataset_id, path_in_repo=parquet_fname, repo_type="dataset")
+        except Exception as e:
+            print(f"File {parquet_fname} failed to delete from repo {dataset_id}.")
+            print(e)
+    else:
+        # worth looking up all files and looking for parquet extensions? why though?
+        print(f"File {parquet_fname} does not exist in dataset {dataset_id}")
+
+
+def lookup_json_files(api:HfApi, dataset_id:str) -> List[str]:
+    """get list of json files in a dataset"""
+    # get list of files and filter for json extension
+    files = api.list_repo_files(dataset_id, repo_type="dataset")
+    json_files = [f for f in files if f.endswith(".json")]
+    return json_files
+
+
+def add_json_files_to_metadata(add_files: List[str], metadata: DatasetDict, dataset_id: str) -> int:
+    """
+    Adds JSON files to the metadata dataset dictionary if their "image_md5" key 
+    is not already present in the "train" split of the metadata.
+
+    Args:
+        add_files (List[str]): A list of file paths (relative to the dataset repository) 
+            to be added to the metadata.
+        metadata (DatasetDict): A dataset dictionary containing metadata, where the 
+            "train" split is expected to have an "image_md5" key.
+        dataset_id (str): The identifier of the dataset repository from which the JSON 
+            files are being added.
+
+    Returns:
+        int: The number of new items added to the "train" split of the metadata.
+    """
+
+    # inplace
+    n = 0
+    for f in add_files:
+        file = hf_hub_download(repo_id=dataset_id, filename=f, repo_type="dataset")
+        with open(file, "r") as f:
+            new = json.load(f)
+        
+        if ("image_md5" not in metadata["train"]) or \
+            not (new["image_md5"] in metadata["train"]["image_md5"]):
+            metadata["train"] = metadata["train"].add_item(new)
+            n += 1
+    return n
+
+        
+def append_new_to_dataset(api:HfApi, dataset_id:str, parquet_fname:str = "data/train-00000-of-00001.parquet"):
+    # procedure from https://github.com/vancauwe/saving-willy-data-sync/
+    # - split into a few functions for reuse (eg in the reset mode)
+    
+    # steps:
+    # - append new json files
+    # - push metadata to hub
+
+    # TODO: put back the exception handling
+
+    json_files = lookup_json_files(api, dataset_id)
+    metadata = load_dataset(dataset_id, data_files=parquet_fname)
+    n = add_json_files_to_metadata(json_files, metadata)
+    print(f"Added {n} files to metadata.")
+    if n > 0:
+        metadata.push_to_hub(dataset_id)
+        
+    return metadata
+
+
+def reset_dataset_rebuild_from_json(api:HfApi, dataset_id:str) -> DatasetDict:
+    """
+    Resets a dataset by deleting existing metadata, rebuilding it entirely from JSON files, 
+    and pushing the updated metadata to the Hugging Face Hub.
+
+    Args:
+        api (HfApi): The Hugging Face API instance used to interact with the dataset.
+        dataset_id (str): The identifier of the dataset to reset and rebuild.
+    Returns:
+        DatasetDict: The rebuilt dataset metadata.
+
+    Notes:
+        - This function is intended for use when the data format has changed, requiring a 
+            complete cleanup and rebuild of the dataset.
+        - The function prints the number of JSON files added and a preview of the metadata.
+    """
+
+    # reset dataset (parquet file), rebuild entirely from json files
+    # usage/context: the data format changed and we need to clean up the dataset
+
+    # - delete meta if exists, 
+    # - create blank dataset
+    # - add metadata from valid json files
+    # - push metea to hub
+    delete_metadata_if_exists(api, dataset_id, parquet_fname="data/train-00000-of-00001.parquet")
+    metadata = create_blank_dataset()
+    json_files = lookup_json_files(api, dataset_id)
+    n = add_json_files_to_metadata(json_files, metadata)
+    print(f"Added {n} files to metadata.")
+    print(pd.DataFrame(metadata['train']))
+
+    if n > 0: 
+        #metadata.push_to_hub(dataset_id, commit_message="refreshed dataset with new format")
+        metadata.push_to_hub(dataset_id)
+    
+    return metadata
+    

--- a/src/example_manual_cleanup.py
+++ b/src/example_manual_cleanup.py
@@ -1,21 +1,26 @@
-import json
+'''
+This script shows how to manually clean up the dataset, through the 
+example of filtering out observations from a specific user, and 
+rebuilding the dataset from scratch. 
+
+'''
 import os 
 import pandas as pd
-
 from huggingface_hub import HfApi
-
 from dataset_handling import create_blank_dataset, lookup_json_files, add_json_files_to_metadata
 
+############################################################
+dataset_id = "Saving-Willy/temp_dataset"
+token = os.getenv("HF_TOKEN")
+dataset_filename = "data/train-00000-of-00001.parquet"
+############################################################
 
 if __name__ == '__main__':
     # example usage, with no actions taken by the demo
     # - see also `reset_dataset_rebuild_from_json`, which wraps most of these 
     #   steps, but doesn't implement the filtering.
-    token = os.getenv("HF_TOKEN")
-    api = HfApi(token=token)
 
-    data_files = "data/train-00000-of-00001.parquet"
-    dataset_id = "Saving-Willy/temp_dataset"
+    api = HfApi(token=token)
     
     # find the uploaded observation+classification files
     all_json_files = lookup_json_files(api, dataset_id)

--- a/src/example_manual_cleanup.py
+++ b/src/example_manual_cleanup.py
@@ -1,0 +1,33 @@
+import json
+import os 
+import pandas as pd
+
+from huggingface_hub import HfApi
+
+from dataset_handling import create_blank_dataset, lookup_json_files, add_json_files_to_metadata
+
+
+if __name__ == '__main__':
+    # example usage, with no actions taken by the demo
+    # - see also `reset_dataset_rebuild_from_json`, which wraps most of these 
+    #   steps, but doesn't implement the filtering.
+    token = os.getenv("HF_TOKEN")
+    api = HfApi(token=token)
+
+    data_files = "data/train-00000-of-00001.parquet"
+    dataset_id = "Saving-Willy/temp_dataset"
+    
+    # find the uploaded observation+classification files
+    all_json_files = lookup_json_files(api, dataset_id)
+
+    # filter files for some criteria, e.g. let's exclude from a specific user 
+    exclude = 'test_data@whale.org'
+    ok_files = [fname for fname in all_json_files if exclude not in fname.split('/')[1]]
+    
+    # create an empty dataset, and add the selected file to it
+    metadata = create_blank_dataset()
+    add_json_files_to_metadata(ok_files, metadata, dataset_id=dataset_id)
+
+    print(pd.DataFrame(metadata['train']))
+    print("Note: to transmit data, use `metadata.push_to_hub(dataset_id)`")
+    

--- a/sync_dataset.py
+++ b/sync_dataset.py
@@ -1,41 +1,34 @@
-from datasets import load_dataset, DownloadMode
-import json
 import os 
-from huggingface_hub import HfApi , hf_hub_download
+from huggingface_hub import HfApi
+from src.dataset_handling import sync_dataset
+
 
 dataset_id = "Saving-Willy/temp_dataset"
-token = os.getenv("HUGGINGFACE_TOKEN")
+token = os.getenv("HF_TOKEN")
+dataset_filename = "data/train-00000-of-00001.parquet"
 
-# Initialize API client
-api = HfApi(token=token)
+if __name__ == '__main__':
+    # Initialize API client
+    api = HfApi(token=token)
 
-# Load all metadata files
-files = api.list_repo_files(dataset_id, repo_type="dataset")
-json_files = [file for file in files if file.endswith(".json")]
+    # add json files to dataset
+    n_new = sync_dataset(
+        api, dataset_id, dataset_filename, 
+        create_dataset_if_not_exists=False)
 
-# Load the metadata compilation 
-try: 
-    data_files = "data/train-00000-of-00001.parquet"
-    metadata = load_dataset(
-                            dataset_id, 
-                            data_files=data_files)
-    # Add new json entries to dataset 
-    for file in json_files: 
-        file = hf_hub_download(repo_id=dataset_id, filename=file, repo_type="dataset")
-        with open(file, "r") as f:
-            new = json.load(f)
-        if not(new["image_md5"] in metadata["train"]["image_md5"]):
-            metadata["train"] = metadata["train"].add_item(new)
-except: 
-    metadata = load_dataset(
-                    dataset_id,
-                    data_files=json_files)
+    if n_new is not None:
+        if n_new == 0:
+            print(f"Info: no action taken, no new observation files found")
+        else:
+            # print the number of new files added
+            print(f"Added {n_new} new files to dataset {dataset_id}.")
+    else:
+        # something went wrong. - want the workflow to fail so nonzero exit  
+        print(f"Failed to sync dataset {dataset_id}.")
+        raise SystemExit(1) 
+    
+    
+    
+    
 
-
-metadata.push_to_hub(dataset_id, token=token)
-
-
-
-
-
-
+    

--- a/sync_dataset.py
+++ b/sync_dataset.py
@@ -1,11 +1,20 @@
+'''
+This script updates any new observations into the combined dataset 
+stored on Hugging Face Hub.
+
+If the operation fails, it exits with non-zero status so the workflow
+fails too (better observability of the failures)
+'''
+
 import os 
 from huggingface_hub import HfApi
 from src.dataset_handling import sync_dataset
 
-
+############################################################
 dataset_id = "Saving-Willy/temp_dataset"
 token = os.getenv("HF_TOKEN")
 dataset_filename = "data/train-00000-of-00001.parquet"
+############################################################
 
 if __name__ == '__main__':
     # Initialize API client
@@ -16,19 +25,7 @@ if __name__ == '__main__':
         api, dataset_id, dataset_filename, 
         create_dataset_if_not_exists=False)
 
-    if n_new is not None:
-        if n_new == 0:
-            print(f"Info: no action taken, no new observation files found")
-        else:
-            # print the number of new files added
-            print(f"Added {n_new} new files to dataset {dataset_id}.")
-    else:
+    if n_new is None:
         # something went wrong. - want the workflow to fail so nonzero exit  
         print(f"Failed to sync dataset {dataset_id}.")
         raise SystemExit(1) 
-    
-    
-    
-    
-
-    


### PR DESCRIPTION
This PR implements a small library to interact with the dataset (stored in the `data` subdir) and the individual observations (stored in the `metadata` subdir).

- simplifies the main script `sync_data.py`
   - removes the try/except around the data fetching, so that the workflow receives a failing exit code if errors are encountered (for better observability)
    - token is loaded from `HF_TOKEN`, resolving #1 
 
- implements a second utility script, `rebuild_dataset.py`, which deletes the existing parquet file, generates a new one from all json files that are in the metadata.
- adds a manually-triggered action for this script. no timed/automated use case is anticipated at present, but useful during development and for cases when the data format is updated.

- the action workflow files are not yet tested, only triggered once in the main branch