### PR TITLE
Fix/no fail on zero files

### DIFF
--- a/src/dataset_handling.py
+++ b/src/dataset_handling.py
@@ -135,7 +135,7 @@ def sync_dataset(
     if not len(json_files):
         # print a warning, and return
         print(f"No json files found in dataset {dataset_id}.")
-        return None
+        return 0
         
     # 1. fetch the dataset (note: doesn't need authentication)
     dataset = load_dataset(dataset_id, data_files=dataset_filename)

--- a/src/dataset_handling.py
+++ b/src/dataset_handling.py
@@ -138,7 +138,13 @@ def sync_dataset(
         return 0
         
     # 1. fetch the dataset (note: doesn't need authentication)
-    dataset = load_dataset(dataset_id, data_files=dataset_filename)
+    try:
+        dataset = load_dataset(dataset_id, data_files=dataset_filename)
+    except FileNotFoundError:
+        print(f"No dataset file {dataset_filename} found in dataset {dataset_id}.")
+        dataset = None
+
+
 
     # if it doesn't exist, either we give up, or we create a blank 
     if not dataset:


### PR DESCRIPTION
minor changes to handle more edge cases:
- when there are no json metadata files
- when there is no parquet file

the module function no longer fails (but the top level `sync_dataset.py` script may still have nonzero exit code under the latter condition